### PR TITLE
print a message in case no photos are found instead of crashing

### DIFF
--- a/upload_photos_by_exif/upload_photos_by_exif.py
+++ b/upload_photos_by_exif/upload_photos_by_exif.py
@@ -350,13 +350,19 @@ def main(argv):
     os.chdir(old_dir)
     time_stamp_list = []
     exist_timestamp = True
+    photos_found = False
     for photo_path in [p for p in photos_path]:
         if ('jpg' in photo_path.lower() or 'jpeg' in photo_path.lower()) and "thumb" not in photo_path.lower():
+            photos_found = True
             try:
                 time_stamp_list.append({"file": photo_path, "timestamp": get_exif(path + photo_path).values})
             except:
                 exist_timestamp = False
                 photos_path = sorted(os.listdir(path), key=itemgetter(1, 2))
+    if not photos_found:
+        print ("No photos found in path \"%s\"." % (path))
+        print ("This program does not search for files in subdirectories of the given path.")
+        sys.exit()
     if exist_timestamp:
         time_stamp_list = sorted(time_stamp_list, key=itemgetter('timestamp'))
         photos_path = []


### PR DESCRIPTION
Currently, the script crashes:
Traceback (most recent call last):
  File "upload_photos_by_exif.py", line 385, in main
    with open(path + "sequence_file.txt", "r+") as sequence_file:
FileNotFoundError: [Errno 2] No such file or directory: '/path/sequence_file.txt'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "upload_photos_by_exif.py", line 488, in <module>
    main(sys.argv[1:])
  File "upload_photos_by_exif.py", line 390, in main
    if latitude is None and longitude is None:

Afterwards, it will print a nice message:
No photos found in path "/path/".
This program does not search for files in subdirectories of the given path.