### PR TITLE
Dockerization

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ If you have installed the requirements into a `virtualenv`, then run
 source <path to virtualenv>/bin/activate
 ```
 before executing the above commands.
+
+## Docker
+
+If you have Docker, you can upload geotagged photos without installing Python nor its requirements :
+```bash
+docker run -it --rm -v /where/your/images/are:/data openstreetcam/upload_photos_by_exif
+```
+

--- a/upload_photos_by_exif/Dockerfile
+++ b/upload_photos_by_exif/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+CMD [ "python", "./upload_photos_by_exif.py", "-p", "/data" ]
+


### PR DESCRIPTION
Because running a container is more straightforward than installing Python3 and some dependencies. Let us make uploading a one-liner:
`docker run -it --rm -v /where/your/images/are:/data openstreetcam/upload_photos_by_exif`