### PR TITLE
Docker for upload_osv_photos and upload_osv_videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ before executing the above commands.
 
 ## Docker
 
-If you have Docker, you can upload geotagged photos without installing Python nor its requirements :
+If you have Docker, you can use these scripts without installing Python nor its requirements:
 ```bash
 docker run -it --rm -v /where/your/images/are:/data openstreetcam/upload_photos_by_exif
+docker run -it --rm -v /where/your/videos/are:/data openstreetcam/upload_osv_videos
+docker run -it --rm -v /where/your/photos/are:/data openstreetcam/upload_osv_photos
 ```
 

--- a/upload_osv_photos/Dockerfile
+++ b/upload_osv_photos/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2
+
+COPY . /opt/osc
+RUN pip install --no-cache-dir -r /opt/osc/requirements.txt
+WORKDIR /opt/osc/cache
+ENTRYPOINT [ "/usr/local/bin/python" , "/opt/osc/upload_photos.py", "-p", "/data" ]
+

--- a/upload_osv_photos/upload_photos.py
+++ b/upload_osv_photos/upload_photos.py
@@ -157,7 +157,7 @@ def main(argv):
                 metaData_name = 'track.txt'
             elif os.path.isfile(path + "/" + dir + "/track.txt.gz"):
                 metaData_name = 'track.txt.gz'
-            dst = path + dir + "/" + 'index_write.txt'
+            dst = path + '/' + dir + "/" + 'index_write.txt'
 
             if os.path.isfile(dst):
                 print ("Metadata backup found")

--- a/upload_osv_photos/upload_photos.py
+++ b/upload_osv_photos/upload_photos.py
@@ -289,9 +289,7 @@ format = {'1.0.3': {'time': 0, 'compas': 12, 'index': 13, 'longitude': 1, 'latit
           '1.0.8': {'time': 0, 'compas': 13, 'index': 14, 'longitude': 1, 'latitude': 2, 'horizontal_accuracy': 4,
                     'ODB': 18},
           'ios_first_version': {'time': 0, 'compas': 1, 'index': 13, 'longitude': 1, 'latitude': 2,
-                                'horizontal_accuracy': 4},
-          '1.1.6': {'time': 0, 'compas': 13, 'index': 15, 'longitude': 1, 'latitude': 2, 'horizontal_accuracy': 4,
-                    'ODB': 19}
+                                'horizontal_accuracy': 4}
           }
 
 

--- a/upload_osv_photos/upload_photos.py
+++ b/upload_osv_photos/upload_photos.py
@@ -289,7 +289,9 @@ format = {'1.0.3': {'time': 0, 'compas': 12, 'index': 13, 'longitude': 1, 'latit
           '1.0.8': {'time': 0, 'compas': 13, 'index': 14, 'longitude': 1, 'latitude': 2, 'horizontal_accuracy': 4,
                     'ODB': 18},
           'ios_first_version': {'time': 0, 'compas': 1, 'index': 13, 'longitude': 1, 'latitude': 2,
-                                'horizontal_accuracy': 4}
+                                'horizontal_accuracy': 4},
+          '1.1.6': {'time': 0, 'compas': 13, 'index': 15, 'longitude': 1, 'latitude': 2, 'horizontal_accuracy': 4,
+                    'ODB': 19}
           }
 
 

--- a/upload_osv_videos/Dockerfile
+++ b/upload_osv_videos/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2
+
+COPY . /opt/osc
+RUN pip install --no-cache-dir -r /opt/osc/requirements.txt
+WORKDIR /opt/osc/cache
+ENTRYPOINT [ "/usr/local/bin/python" , "/opt/osc/upload_video.py", "-p", "/data" ]
+

--- a/upload_osv_videos/upload_video.py
+++ b/upload_osv_videos/upload_video.py
@@ -308,9 +308,7 @@ format = {
     '1.1.3': {'time': 0, 'compas': 13, 'videoIndex': 14, 'tripFrameIndex': 15, 'longitude': 1, 'latitude': 2,
             'horizontal_accuracy': 4, 'ODB': 19},
     '1.1.5': {'time': 0, 'compas': 13, 'videoIndex': 14, 'tripFrameIndex': 15, 'longitude': 1, 'latitude': 2,
-              'horizontal_accuracy': 4, 'ODB': 19},
-    '1.1.6': {'time': 0, 'compas': 13, 'videoIndex': 14, 'tripFrameIndex': 15, 'longitude': 1, 'latitude': 2,
-              'horizontal_accuracy': 4, 'ODB': 19},
+              'horizontal_accuracy': 4, 'ODB': 19}
 }
 
 

--- a/upload_osv_videos/upload_video.py
+++ b/upload_osv_videos/upload_video.py
@@ -308,7 +308,9 @@ format = {
     '1.1.3': {'time': 0, 'compas': 13, 'videoIndex': 14, 'tripFrameIndex': 15, 'longitude': 1, 'latitude': 2,
             'horizontal_accuracy': 4, 'ODB': 19},
     '1.1.5': {'time': 0, 'compas': 13, 'videoIndex': 14, 'tripFrameIndex': 15, 'longitude': 1, 'latitude': 2,
-              'horizontal_accuracy': 4, 'ODB': 19}
+              'horizontal_accuracy': 4, 'ODB': 19},
+    '1.1.6': {'time': 0, 'compas': 13, 'videoIndex': 14, 'tripFrameIndex': 15, 'longitude': 1, 'latitude': 2,
+              'horizontal_accuracy': 4, 'ODB': 19},
 }
 
 

--- a/upload_photos_by_exif/Dockerfile
+++ b/upload_photos_by_exif/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3
 
-WORKDIR /usr/src/app
-COPY . .
-RUN pip install --no-cache-dir -r requirements.txt
-ENTRYPOINT [ "/usr/local/bin/python" , "./upload_photos_by_exif.py", "-p", "/data" ]
+COPY . /opt/osc
+RUN pip install --no-cache-dir -r /opt/osc/requirements.txt
+WORKDIR /opt/osc/cache
+ENTRYPOINT [ "/usr/local/bin/python" , "/opt/osc/upload_photos_by_exif.py", "-p", "/data" ]
 

--- a/upload_photos_by_exif/Dockerfile
+++ b/upload_photos_by_exif/Dockerfile
@@ -3,5 +3,5 @@ FROM python:3
 WORKDIR /usr/src/app
 COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
-CMD [ "python", "./upload_photos_by_exif.py", "-p", "/data" ]
+ENTRYPOINT [ "/usr/local/bin/python" , "./upload_photos_by_exif.py", "-p", "/data" ]
 


### PR DESCRIPTION
Here is a dockerization for the remaining scripts upload_osv_photos and upload_osv_videos.
Now, all three scripts can be run without installing anything but Docker.
I updated the README accordingly.