### PR TITLE
Fix typo 's/form/from/'

### DIFF
--- a/osc/osc_actions.py
+++ b/osc/osc_actions.py
@@ -88,8 +88,8 @@ def finish_upload(url_finish, path, access_token, id_sequence):
                    }
     f = requests.post(url_finish, data=data_finish)
     if f.json()['status']['apiCode'] == '600':
-        print(("Finish uploading form dir: " + path + " with sequence id: " + str(id_sequence)))
+        print(("Finish uploading from dir: " + path + " with sequence id: " + str(id_sequence)))
     else:
-        print(("FAIL uploading form dir: " + path))
+        print(("FAIL uploading from dir: " + path))
         print("Error: ")
         print(f.json())


### PR DESCRIPTION
Fixing typo in output: `s/form/from/`.

This is _very_ loosely related to https://github.com/openstreetcam/upload-scripts/issues/56