### PR TITLE
Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# ctags
+/tags
+
+# vim swap
+.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: default ctags pycodestyle clean
+
+default: ctags pycodestyle
+
+ctags:
+	ctags ./
+
+pycodestyle:
+	pycodestyle --max-line-length=100 ./
+
+clean:
+	rm tags

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: default ctags pycodestyle clean
+.PHONY: default pycodestyle clean
 
-default: ctags pycodestyle
+default: tags pycodestyle
 
-ctags:
+tags: *.py
 	ctags ./
 
 pycodestyle:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ rauth==0.7.2
 ExifRead==2.1.2
 tqdm==4.29.1
 piexif==1.1.2
-
+pycodestyle==2.5.0


### PR DESCRIPTION
This adds a Makefile that builds the ctags index and runs the `pycodetest` script that replaces traditional `pep8`. Instead of moving code around to conform to the traditional 79-character length limit, I set the limit to 100.