### PR TITLE
Docker Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,7 @@ dmypy.json
 
 # vim swap
 .swp
+
+# requirements.txt copy used for Docker
+docker/requirements.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,5 @@ dmypy.json
 # requirements.txt copy used for Docker
 docker/requirements.txt
 
+# ignore images Docker helper directory
+images/*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: default pycodestyle clean
+.PHONY: default pycodestyle clean docker help
 
-default: tags pycodestyle
+default: help
+
+help:
+	@echo 'tags: Build ctags'
+	@echo 'pycodestyle: run pycodestyle (pep8)'
+	@echo 'docker: build docker containter'
+	@echo 'clean: remove development and docker debris'
 
 tags: *.py
 	ctags ./
@@ -9,4 +15,11 @@ pycodestyle:
 	pycodestyle --max-line-length=100 ./
 
 clean:
-	rm tags
+	if [ -f tags ] ; then rm tags; fi
+	if [ -f docker/requirements.txt ]; then rm docker/requirements.txt; fi
+
+docker/requirements.txt:
+	cp requirements.txt docker/requirements.txt
+
+docker: docker/requirements.txt
+	docker build -t osc-up docker

--- a/README.md
+++ b/README.md
@@ -60,3 +60,12 @@ python osc_tools.py generate_exif -h
 python osc_tools.py generate_exif -p ~/OSC_seqences/Sequence1
 
 ```
+
+##### Docker
+To run the scripts inside a Docker container:
+```
+make docker
+docker run -Pit osc-up osc_tools.py
+docker run -Pit --mount type=bind,source="$(pwd)",target=/opt/osc osc-up /opt/osc/osc_tools.py
+```
+The images directory in the repo will be available in the container at /opt/osc/images

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:buster-slim
+
+COPY requirements.txt /etc/requirements.txt
+COPY git-blacklist /etc/apt/preferences.d/git-blacklist
+
+RUN apt-get update && apt-get -y upgrade && apt-get -y install python3 python3-pip && pip3 install -r /etc/requirements.txt && apt-get -y clean
+

--- a/docker/git-blacklist
+++ b/docker/git-blacklist
@@ -1,0 +1,3 @@
+Package: git
+Pin: release *
+Pin-Priority: -1

--- a/images/README
+++ b/images/README
@@ -1,0 +1,2 @@
+This is a directory ignored by git that exists to help easily mount an image
+directory along with the upload-scripts code to a Docker container.

--- a/osc_discoverer.py
+++ b/osc_discoverer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This script is used to discover video files, sensor info and return Sequences."""
 import os
 import json

--- a/osc_tools.py
+++ b/osc_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Tools developed by OpenStreetCam to help contributors."""
 
 import logging

--- a/visual_data_discover.py
+++ b/visual_data_discover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """This script is used to discover video files, or photo files"""
 
 import os


### PR DESCRIPTION
I took a look at removing the PEP 576 type annotations from the codebase so that it could run on Debian Stable or on a Raspberry Pi, and saw that that it is used extensively.  Type annotations require Python 3.6, both Debian and Raspbian in their stable releases only support Python 3.5.

This PR adds a `docker` Makefile recipe to build a Docker container for `upload-scripts` that runs Python 3.7.2, as provided by not-yet-stable Debian Buster.