### PR TITLE
Fix Latitude and Longitude EXIF Processing

### DIFF
--- a/exif_processing.py
+++ b/exif_processing.py
@@ -114,7 +114,7 @@ def gps_latitude(gps_data: {str: str}) -> Optional[float]:
         dms_values = gps_data[ExifTags.GPS_LATITUDE.value]
         _latitude = __dms_to_dd(dms_values)
         if ExifTags.GPS_LATITUDE_REF.value in gps_data and \
-                gps_data[ExifTags.GPS_LATITUDE_REF.value] == CardinalDirection.S.value:
+                (str(gps_data[ExifTags.GPS_LATITUDE_REF.value]) == str(CardinalDirection.S.value)):
             # cardinal direction is S so the latitude should be negative
             _latitude = -1 * _latitude
 
@@ -130,7 +130,7 @@ def gps_longitude(gps_data: {str: str}) -> Optional[float]:
         dms_values = gps_data[ExifTags.GPS_LONGITUDE.value]
         _longitude = __dms_to_dd(dms_values)
         if ExifTags.GPS_LONGITUDE_REF.value in gps_data and \
-                gps_data[ExifTags.GPS_LONGITUDE_REF.value] == CardinalDirection.W.value:
+                str(gps_data[ExifTags.GPS_LONGITUDE_REF.value]) == str(CardinalDirection.W.value):
             # cardinal direction is W so the longitude should be negative
             _longitude = -1 * _longitude
 

--- a/visual_data_discover.py
+++ b/visual_data_discover.py
@@ -92,6 +92,7 @@ class ExifPhotoDiscoverer(PhotoDiscovery):
         photo.gps_speed = exif_processing.gps_speed(tags_data)
         photo.gps_altitude = exif_processing.gps_altitude(tags_data)
         photo.gps_compass = exif_processing.gps_compass(tags_data)
+        LOGGER.debug("lat/lon: %f/%f", photo.latitude, photo.longitude)
         return photo
 
     @classmethod


### PR DESCRIPTION
Because `ExifTags.GPS_LONGITUDE_REF.value` and CardinalDirection.W.value` evaluate to different types, they aren't comparable and longitude is not correctly set to a negative value in the western hemisphere.

The same problem exists for `ExifTags.GPS_LATITUDE_REF.value` and `CardinalDirection.S.value`, which is also fixed in this PR.

This fixes https://github.com/openstreetcam/upload-scripts/issues/76