### PR TITLE
fixed missing current location from sequence after restarting scripts

### DIFF
--- a/osc_api_models.py
+++ b/osc_api_models.py
@@ -106,7 +106,11 @@ class OSCSequence:
 
     def location(self) -> str:
         """this method returns the string representation of a OSCSequence location"""
+        if self.latitude is not None and self.longitude is not None:
+            return str(self.latitude) + "," + str(self.longitude)
+
         if self.photos:
             photo = self.photos[0]
             return str(photo.latitude) + "," + str(photo.longitude)
         return ""
+


### PR DESCRIPTION
**Scenario:**
1. Start sequence discovery
2. Close script after sequence was discovered but before the upload has started
3. Start sequence upload

**Result:** 
- sequence.location() returns None

**Expected result:** 
- sequence.location() returns the location for that sequence. 
